### PR TITLE
Alignment links missing / in indexes

### DIFF
--- a/templates/element/genericElements/IndexTable/Fields/alignments.php
+++ b/templates/element/genericElements/IndexTable/Fields/alignments.php
@@ -8,7 +8,7 @@ if ($field['scope'] === 'individuals') {
             '<div><span class="fw-bold">%s</span> @ %s <a href="#" class="fas fa-trash .text-reset .text-decoration-none" onClick="%s"></a></div>',
             h($alignment['type']),
             sprintf(
-                '<a href="%sorganisations/view/%s">%s</a>',
+                '<a href="%s/organisations/view/%s">%s</a>',
                 $baseurl,
                 h($alignment['organisation']['id']),
                 h($alignment['organisation']['name'])
@@ -28,7 +28,7 @@ if ($field['scope'] === 'individuals') {
             '<div>[<span class="fw-bold">%s</span>] %s <a href="#" class="fas fa-trash .text-reset .text-decoration-none" onClick="%s"></a></div>',
             h($alignment['type']),
             sprintf(
-                '<a href="%sindividuals/view/%s">%s</a>',
+                '<a href="%s/individuals/view/%s">%s</a>',
                 $baseurl,
                 h($alignment['individual']['id']),
                 h($alignment['individual']['email'])


### PR DESCRIPTION
When baseurl is configured in the UI as: `https://cerebrate.example.com/` (`App.baseurl` is `https:\/\/cerebrate.example.com\/` in config.json  

a `/` between the `$baseurl` and the url path appears to be missing: 
 - When viewing the index of all individuals (/individuals/index), links to the Organisations in their Alignments are missing a `/`
 - When viewing an organisation that includes individuals with an alignment, links to the Individuals are missing a `/`