### PR TITLE
Alignment links missing / in 'single' view

### DIFF
--- a/templates/element/genericElements/SingleViews/Fields/alignmentField.php
+++ b/templates/element/genericElements/SingleViews/Fields/alignmentField.php
@@ -14,7 +14,7 @@ if ($field['scope'] === 'individuals') {
             '<div><span class="fw-bold">%s</span> @ %s <a href="#" class="fas fa-trash" onClick="%s"></a></div>',
             h($alignment['type']),
             sprintf(
-                '<a href="%sorganisations/view/%s">%s</a>',
+                '<a href="%s/organisations/view/%s">%s</a>',
                 $baseurl,
                 h($alignment['organisation']['id']),
                 h($alignment['organisation']['name'])
@@ -34,7 +34,7 @@ if ($field['scope'] === 'individuals') {
             '<div>[<span class="fw-bold">%s</span>] %s <a href="#" class="fas fa-trash" onClick="%s"></a></div>',
             h($alignment['type']),
             sprintf(
-                '<a href="%sindividuals/view/%s">%s</a>',
+                '<a href="%s/individuals/view/%s">%s</a>',
                 $baseurl,
                 h($alignment['individual']['id']),
                 h($alignment['individual']['email'])


### PR DESCRIPTION
When baseurl is configured in the UI as: `https://cerebrate.example.com/` (`App.baseurl` is `https:\/\/cerebrate.example.com\/` in config.json  

a `/` between the `$baseurl` and the url path appears to be missing: 
 - When viewing an individual and their alignments (/individuals/view/123), links to the Organisations in their Alignments are missing a `/`
 - When viewing an organisation, links to the individuals with an alignment to the organisation are missing a `/`