### PR TITLE
Added checks for KC being enabled (#106)

### DIFF
--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -57,7 +57,9 @@ class UsersTable extends AppTable
     private function initAuthBehaviors()
     {
         if (!empty(Configure::read('keycloak'))) {
-            $this->addBehavior('AuthKeycloak');
+            if (Configure::read('keycloak.enabled')) {
+                $this->addBehavior('AuthKeycloak');
+            }
         }
     }
 
@@ -188,7 +190,9 @@ class UsersTable extends AppTable
     public function enrollUserRouter($data): void
     {
         if (!empty(Configure::read('keycloak'))) {
-            $this->enrollUser($data);
+            if (Configure::read('keycloak.enabled')) {
+                $this->enrollUser($data);
+            }
         }
     }
 }


### PR DESCRIPTION
Initialisation of Auth behaviour and enrollment of users in KC, was dependent on the presence of a `keycloak` section in config.json

Added checks to ensure KC is configured as "enabled", rather than just checking if a keycloak config section was present.