### PR TITLE
Update PHP socket to version-agnostic

### DIFF
--- a/INSTALL/cerebrate_nginx.conf
+++ b/INSTALL/cerebrate_nginx.conf
@@ -28,7 +28,7 @@ server {
        location ~ \.php$ {
                try_files $uri =404;
                fastcgi_split_path_info ^(.+\.php)(/.+)$;
-               fastcgi_pass            unix:/var/run/php/php7.4-fpm.sock;
+               fastcgi_pass            unix:/var/run/php/php-fpm.sock;
                fastcgi_index           index.php;
                include                 fastcgi_params;
                fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
The nginx example config refers to PHP 7 FPM socket, but the newer version is recommended. Changing it to the non-versioned socket to allow quick start.