### PR TITLE
fix: use numeric values within range for debug level setting

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -25,7 +25,7 @@ return [
      * Development Mode:
      * true: Errors and warnings shown.
      */
-    'debug' => filter_var(env('DEBUG', false), FILTER_VALIDATE_BOOLEAN),
+    'debug' => filter_var(env('DEBUG', 0), FILTER_VALIDATE_INT, array("options" => array("min_range"=>0, "max_range"=>1))),
 
     /*
      * Security and encryption configuration

--- a/src/Model/Table/SettingProviders/CerebrateSettingsProvider.php
+++ b/src/Model/Table/SettingProviders/CerebrateSettingsProvider.php
@@ -346,11 +346,11 @@ class CerebrateSettingsProvider extends BaseSettingsProvider
                             'description' => __('The debug level of the instance'),
                             'default' => 0,
                             'options' => [
-                                false => __('Debug Off'),
-                                true => __('Debug On'),
+                                0 => __('Debug Off'),
+                                1 => __('Debug On'),
                             ],
                             'test' => function ($value, $setting, $validator) {
-                                $validator->range('value', [0, 2]);
+                                $validator->range('value', [0, 1]);
                                 return testValidator($value, $validator);
                             },
                         ],


### PR DESCRIPTION
Not having debug set in config.json led to some weird stuff in the GUI:
![image](https://github.com/user-attachments/assets/06dc5571-8c1c-472c-87b5-04a80cfe1bf8)

range() validator returns false when it gets a boolean as input (it checks for numeric input). Range is also inclusive.

Note that this change probably doesn't make sense if you don't intend to have more than 2 debug levels at some point. Then it probably makes more sense to change the field type.