### PR TITLE
fix: users settings view throws internal server error when accessed w…

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -487,7 +487,7 @@ class UsersController extends AppController
     {
         $editingAnotherUser = false;
         $currentUser = $this->ACL->getUser();
-        if ((empty($currentUser['role']['perm_community_admin']) && empty($currentUser['role']['perm_group_admin'])) || $user_id == $currentUser->id) {
+        if ((empty($currentUser['role']['perm_community_admin']) && empty($currentUser['role']['perm_group_admin'])) || empty($user_id) || $user_id == $currentUser->id) {
             $user = $currentUser;
         } else {
             $user = $this->Users->get($user_id, [


### PR DESCRIPTION
…ithout user id

By default, just load current user's view, instead of throwing an error.
This was happening when you click on "home" button on `/users/settings/<id>` view because it points to `/users/settings`