### PR TITLE
fix: migrations not working on install due to debug mode not being bo…

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -25,7 +25,7 @@ return [
      * Development Mode:
      * true: Errors and warnings shown.
      */
-    'debug' => filter_var(env('DEBUG', 0), FILTER_VALIDATE_INT, array("options" => array("min_range"=>0, "max_range"=>1))),
+    'debug' => filter_var(env('DEBUG', false), FILTER_VALIDATE_BOOLEAN),
 
     /*
      * Security and encryption configuration

--- a/src/Model/Table/SettingProviders/CerebrateSettingsProvider.php
+++ b/src/Model/Table/SettingProviders/CerebrateSettingsProvider.php
@@ -346,8 +346,8 @@ class CerebrateSettingsProvider extends BaseSettingsProvider
                             'description' => __('The debug level of the instance'),
                             'default' => 0,
                             'options' => [
-                                0 => __('Debug Off'),
-                                1 => __('Debug On'),
+                                false => __('Debug Off'),
+                                true => __('Debug On'),
                             ],
                             'test' => function ($value, $setting, $validator) {
                                 $validator->range('value', [0, 1]);


### PR DESCRIPTION
…olean

I'm sorry, it looks like my earlier change breaks the install / migrations. Not sure what the proper way forward is, so just proposing to revert for now to make migrations work again. Putting the stacktrace below:

`  TypeError: Cake\Error\Renderer\ConsoleErrorRenderer::render(): Argument #2 ($debug) must be of type bool, int given, called in /var/www/cerebrate/vendor/cakephp/cakephp/src/Error/ErrorTrap.php on line 147 and defined in /var/www/cerebrate/vendor/cakephp/cakephp/src/Error/Renderer/ConsoleErrorRenderer.php:67
Stack trace:
#0 /var/www/cerebrate/vendor/cakephp/cakephp/src/Error/ErrorTrap.php(147): Cake\Error\Renderer\ConsoleErrorRenderer->render()
#1 [internal function]: Cake\Error\ErrorTrap->handleError()
#2 /var/www/cerebrate/vendor/cakephp/cakephp/src/Core/functions.php(318): trigger_error()
#3 /var/www/cerebrate/vendor/cakephp/cakephp/src/Database/Connection.php(506): Cake\Core\deprecationWarning()
#4 /var/www/cerebrate/vendor/cakephp/migrations/src/CakeAdapter.php(83): Cake\Database\Connection->newQuery()
#5 /var/www/cerebrate/vendor/robmorgan/phinx/src/Phinx/Migration/AbstractMigration.php(215): Migrations\CakeAdapter->getQueryBuilder()
#6 /var/www/cerebrate/config/Migrations/20211123152707_user_org.php(33): Phinx\Migration\AbstractMigration->getQueryBuilder()
#7 /var/www/cerebrate/vendor/robmorgan/phinx/src/Phinx/Migration/Manager/Environment.php(108): UserOrg->change()
#8 /var/www/cerebrate/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php(388): Phinx\Migration\Manager\Environment->executeMigration()
#9 /var/www/cerebrate/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php(359): Phinx\Migration\Manager->executeMigration()
#10 /var/www/cerebrate/vendor/robmorgan/phinx/src/Phinx/Console/Command/Migrate.php(122): Phinx\Migration\Manager->migrate()
#11 /var/www/cerebrate/vendor/cakephp/migrations/src/Command/Phinx/CommandTrait.php(37): Phinx\Console\Command\Migrate->execute()
#12 /var/www/cerebrate/vendor/cakephp/migrations/src/Command/Phinx/Migrate.php(85): Migrations\Command\Phinx\Migrate->parentExecute()
#13 /var/www/cerebrate/vendor/symfony/console/Command/Command.php(326): Migrations\Command\Phinx\Migrate->execute()
#14 /var/www/cerebrate/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run()
#15 /var/www/cerebrate/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand()
#16 /var/www/cerebrate/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun()
#17 /var/www/cerebrate/vendor/cakephp/migrations/src/Command/MigrationsCommand.php(126): Symfony\Component\Console\Application->run()
#18 /var/www/cerebrate/vendor/cakephp/cakephp/src/Console/BaseCommand.php(190): Migrations\Command\MigrationsCommand->execute()
#19 /var/www/cerebrate/vendor/cakephp/migrations/src/Command/MigrationsCommand.php(198): Cake\Console\BaseCommand->run()
#20 /var/www/cerebrate/vendor/cakephp/cakephp/src/Console/CommandRunner.php(334): Migrations\Command\MigrationsCommand->run()
#21 /var/www/cerebrate/vendor/cakephp/cakephp/src/Console/CommandRunner.php(172): Cake\Console\CommandRunner->runCommand()
#22 /var/www/cerebrate/bin/cake.php(12): Cake\Console\CommandRunner->run()
#23 {main}`