### PR TITLE
Improve template metafields validation

### DIFF
--- a/src/Model/Table/MetaTemplateFieldsTable.php
+++ b/src/Model/Table/MetaTemplateFieldsTable.php
@@ -47,6 +47,22 @@ class MetaTemplateFieldsTable extends AppTable
             ->notEmptyString('field')
             ->notEmptyString('type')
             ->requirePresence(['field', 'type'], 'create');
+
+        $jsonArrayRule = [
+            'rule' => function ($value, $context) {
+                if ($value === null || $value === '' || is_array($value)) {
+                    return true;
+                }
+
+                $decoded = json_decode($value, true);
+                return is_array($decoded) && array_keys($decoded) === range(0, count($decoded) - 1);
+            },
+            'message' => 'This field must be a valid JSON array.'
+        ];
+
+        $validator->add('sane_default', 'validJsonArray', $jsonArrayRule);
+        $validator->add('values_list', 'validJsonArray', $jsonArrayRule);
+
         return $validator;
     }
 

--- a/src/Model/Table/MetaTemplatesTable.php
+++ b/src/Model/Table/MetaTemplatesTable.php
@@ -128,7 +128,7 @@ class MetaTemplatesTable extends AppTable
             if ($success) {
                 $files_processed[] = $template['uuid'];
             } else {
-                $updatesErrors[] = $errors;
+                $updatesErrors[] = implode(', ', Hash::extract($errors, '{n}.message'));
             }
         }
         $results = [
@@ -226,7 +226,7 @@ class MetaTemplatesTable extends AppTable
             $files_processed[] = $templateOnDisk['uuid'];
         }
         if (!empty($errors)) {
-            $updatesErrors[] = $errors;
+            $updatesErrors[] = implode(', ', Hash::extract($errors, '{n}.message'));
         }
         $results = [
             'update_errors' => $updatesErrors,
@@ -843,7 +843,7 @@ class MetaTemplatesTable extends AppTable
             }
         }
         if (empty($metaTemplate)) {
-            $errors[] = new UpdateError(false, __('Could not save the template.'), $metaTemplate->getErrors());
+            $errors[] = new UpdateError(false, __('Could not save the template.'));
             return false;
         }
         return true;


### PR DESCRIPTION
when creating dropdown fields incorrect values for `sane_default` and `values_list` can break the application