### PR TITLE
fix: RecordNotFoundException prevent brood download 

### DIFF
--- a/src/Model/Table/MetaFieldsTable.php
+++ b/src/Model/Table/MetaFieldsTable.php
@@ -73,7 +73,11 @@ class MetaFieldsTable extends AppTable
         if (empty($entityData['meta_template_field_id'])) {
             return true;
         }
-        $metaTemplateField = $metaFieldsTable->MetaTemplateFields->get($entityData['meta_template_field_id']);
+        $templateFieldId = $entityData['meta_template_field_id'];
+        if (!$metaFieldsTable->MetaTemplateFields->exists(['id' => $templateFieldId])) {
+            return false; 
+        }
+        $metaTemplateField = $metaFieldsTable->MetaTemplateFields->get($templateFieldId);
         return $this->isValidMetaFieldForMetaTemplateField($value, $metaTemplateField);
     }
 


### PR DESCRIPTION
Add existence check before calling `get()` in MetaFieldsTable::isValidMetaField() to avoid unhandled RecordNotFoundException when validating a MetaField that  references a missing meta_template_field_id.

I'm unsure of the ramifications of, and have refrained from, introducing buildRules comparable to other Models:

# not added
```php

    public function buildRules(RulesChecker $rules): RulesChecker    {
        $rules->add($rules->existsIn(['meta_template_id'], 'MetaTemplates'), [
            'errorField' => 'meta_template_id',
            'message' => __('The selected meta template does not exist.'),
        ]);

        $rules->add($rules->existsIn(['meta_template_field_id'], 'MetaTemplateFields'), [
            'errorField' => 'meta_template_field_id',
            'message' => __('The selected meta template field does not exist.'),
        ]);

        $rules->add($rules->existsIn(['meta_template_directory_id'], 'MetaTemplateNameDirectory'), [
            'errorField' => 'meta_template_directory_id',
            'message' => __('The selected meta template directory does not exist.'),
        ]);

        return $rules;
    }
 
```
Refs: #204