### PR TITLE
fix: [ACLComponent] correct logic for AND permission rules

### DIFF
--- a/src/Controller/Component/ACLComponent.php
+++ b/src/Controller/Component/ACLComponent.php
@@ -614,7 +614,7 @@ class ACLComponent extends Component
                 } elseif (isset($permissions['AND'])) {
                     $access = true;
                     foreach ($permissions['AND'] as $permission) {
-                        if ($role[$permission]) {
+                        if (!$role[$permission]) {
                             $access = false;
                         }
                     }


### PR DESCRIPTION
I suppose a break; could be added in these IFs as well