### PR TITLE
fix: [UserSetting:edit] use user setting user id to check ACL, instea…

### DIFF
--- a/src/Controller/UserSettingsController.php
+++ b/src/Controller/UserSettingsController.php
@@ -126,7 +126,7 @@ class UserSettingsController extends AppController
         } else {
             $validUsers = $this->Users->find('list')->select(['id', 'username'])->order(['username' => 'asc'])->all()->toArray();
         }
-        if (!isset($validUsers[$id])) {
+        if (!isset($validUsers[$entity->user_id])) {
             throw new MethodNotAllowedException(__('You do not have permission to edit this user setting.'));
         }
         $dropdownData = [


### PR DESCRIPTION
…d of user setting id

Tests done:
1. Before change, user couldn't edit own user setting
2. After change, normal user could still edit own user setting, but not that of others