### PR TITLE
fix: [UserSetting:ACL] fetch user object related to setting to do ACL…

### DIFF
--- a/src/Controller/UserSettingsController.php
+++ b/src/Controller/UserSettingsController.php
@@ -293,9 +293,9 @@ class UserSettingsController extends AppController
         if (empty($setting)) {
             return false;
         }
-        $user = $this->UserSettings->find()->where([
-            'id' => $setting->id
-        ])->first();
+        $user = $this->UserSettings->Users->find()
+            ->where(['Users.id' => $setting->user_id])
+            ->first();
 
         if ($this->ACL->canEditUser($currentUser, $user)) {
             return true;


### PR DESCRIPTION
… check in isLoggedUserAllowedToEdit


Just did a quick verification that this was indeed an issue / blocking users from viewing / deleting
And that afterwards I could view/delete own user setting as a normal user, but got locked out from viewing those of other users.