### PR TITLE
Normalize GPG subkey expirations and fix encryption subkey validation

### DIFF
--- a/src/Model/Table/EncryptionKeysTable.php
+++ b/src/Model/Table/EncryptionKeysTable.php
@@ -96,7 +96,7 @@ class EncryptionKeysTable extends AppTable
             $sortedKeys = ['valid' => 0, 'expired' => 0, 'noEncrypt' => 0];
             foreach ($key->getSubKeys() as $subKey) {
                 $expiration = $subKey->getExpirationDate();
-                if ($expiration != 0 && $currentTimestamp > $expiration) {
+                if ($this->isSubKeyExpired($expiration, $currentTimestamp)) {
                     $sortedKeys['expired']++;
                     continue;
                 }
@@ -121,6 +121,31 @@ class EncryptionKeysTable extends AppTable
             $result[2] = $e->getMessage();
         }
         return $result;
+    }
+
+
+    /**
+     * Checks whether a GPG subkey expiration value is in the past.
+     *
+     * Crypt_GPG returns expiration dates as DateTimeInterface instances, but
+     * older or mocked implementations may still use Unix timestamps. Normalize
+     * both formats before comparing them to the current timestamp.
+     *
+     * @param \DateTimeInterface|int|string|null $expiration Expiration date from Crypt_GPG.
+     * @param int $currentTimestamp Current Unix timestamp.
+     * @return bool
+     */
+    private function isSubKeyExpired($expiration, int $currentTimestamp): bool
+    {
+        if (empty($expiration)) {
+            return false;
+        }
+
+        if ($expiration instanceof \DateTimeInterface) {
+            $expiration = $expiration->getTimestamp();
+        }
+
+        return is_numeric($expiration) && $currentTimestamp > (int)$expiration;
     }
 
 

--- a/tests/TestCase/Model/Table/EncryptionKeysTableTest.php
+++ b/tests/TestCase/Model/Table/EncryptionKeysTableTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Model\Table;
+
+use App\Model\Entity\EncryptionKey;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class EncryptionKeysTableTest extends TestCase
+{
+    public const FINGERPRINT = 'ACBF1CE4A8789AA33605A538D47CD68399535AE3';
+
+    public function testVerifySingleGpgAcceptsDateTimeExpirationForEncryptionSubkey(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('EncryptionKeys');
+        $table->gpg = $this->buildGpgStub([
+            $this->buildSubKeyStub(new \DateTimeImmutable('@' . (time() + 86400)), true),
+        ]);
+
+        $result = $table->verifySingleGPG(new EncryptionKey(['encryption_key' => 'dummy-key']));
+
+        $this->assertTrue($result[0]);
+        $this->assertArrayNotHasKey(2, $result);
+        $this->assertSame(self::FINGERPRINT, $result[4]);
+        $this->assertSame(self::FINGERPRINT, $result[5]);
+    }
+
+    public function testVerifySingleGpgRejectsExpiredDateTimeEncryptionSubkey(): void
+    {
+        $table = TableRegistry::getTableLocator()->get('EncryptionKeys');
+        $table->gpg = $this->buildGpgStub([
+            $this->buildSubKeyStub(new \DateTimeImmutable('@' . (time() - 86400)), true),
+        ]);
+
+        $result = $table->verifySingleGPG(new EncryptionKey(['encryption_key' => 'dummy-key']));
+
+        $this->assertFalse($result[0]);
+        $this->assertStringContainsString('does not include a valid subkey', $result[2]);
+        $this->assertStringContainsString('expired', $result[2]);
+    }
+
+    /**
+     * @param array $subKeys Subkey stubs to return from the fake key.
+     * @return object
+     */
+    private function buildGpgStub(array $subKeys): object
+    {
+        return new class ($subKeys) {
+            /**
+             * @var array
+             */
+            private $subKeys;
+
+            public function __construct(array $subKeys)
+            {
+                $this->subKeys = $subKeys;
+            }
+
+            public function keyInfo(string $keyData): array
+            {
+                return [new class ($this->subKeys) {
+                    /**
+                     * @var array
+                     */
+                    private $subKeys;
+
+                    public function __construct(array $subKeys)
+                    {
+                        $this->subKeys = $subKeys;
+                    }
+
+                    public function getPrimaryKey(): object
+                    {
+                        return new class {
+                            public function getFingerprint(): string
+                            {
+                                return EncryptionKeysTableTest::FINGERPRINT;
+                            }
+                        };
+                    }
+
+                    public function getSubKeys(): array
+                    {
+                        return $this->subKeys;
+                    }
+                }];
+            }
+        };
+    }
+
+    /**
+     * @param \DateTimeInterface|int|string|null $expiration Expiration value to return.
+     * @param bool $canEncrypt Whether the subkey can encrypt.
+     * @return object
+     */
+    private function buildSubKeyStub($expiration, bool $canEncrypt): object
+    {
+        return new class ($expiration, $canEncrypt) {
+            /**
+             * @var \DateTimeInterface|int|string|null
+             */
+            private $expiration;
+
+            /**
+             * @var bool
+             */
+            private $canEncrypt;
+
+            public function __construct($expiration, bool $canEncrypt)
+            {
+                $this->expiration = $expiration;
+                $this->canEncrypt = $canEncrypt;
+            }
+
+            public function getExpirationDate()
+            {
+                return $this->expiration;
+            }
+
+            public function canEncrypt(): bool
+            {
+                return $this->canEncrypt;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Crypt_GPG returns subkey expiration dates as `DateTimeInterface` objects in some environments, but the code compared expiration values directly to an integer timestamp which could mark valid encryption subkeys as expired. 
- Add regression coverage to ensure PGP keys with `DateTime` expirations are accepted when their encryption subkey is still valid.

### Description
- Add a helper `isSubKeyExpired($expiration, int $currentTimestamp)` to `src/Model/Table/EncryptionKeysTable.php` that normalizes `DateTimeInterface`, numeric and string expiration representations before comparison. 
- Replace the direct numeric comparison in `verifySingleGPG()` with a call to `isSubKeyExpired()` so expired / sign-only / valid counters are computed correctly. 
- Add unit tests in `tests/TestCase/Model/Table/EncryptionKeysTableTest.php` which use inline fake GPG/key/subkey stubs to cover both future-dated and expired `DateTime` expiration values.

### Testing
- Ran `php -l src/Model/Table/EncryptionKeysTable.php` and `php -l tests/TestCase/Model/Table/EncryptionKeysTableTest.php` and both reported no syntax errors. 
- Ran `SECURITY_SALT=test SKIP_DB_MIGRATIONS=1 vendor/bin/phpunit tests/TestCase/Model/Table/EncryptionKeysTableTest.php` and the new tests passed (`OK (2 tests, 7 assertions)`), with an unrelated PHP 8.4 deprecation notice from `GpgTool::__construct`. 
- Ran `vendor/bin/phpcs --standard=vendor/cakephp/cakephp-codesniffer/CakePHP tests/TestCase/Model/Table/EncryptionKeysTableTest.php` and the test file passed the coding standard checks. 
- Verified `git diff --check` produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26710e34088324a904dfd0261384ab)