### PR TITLE
fix: enisa-csirt-inventory meta_template uppercase country codes

### DIFF
--- a/libraries/default/meta_fields/enisa-csirt-inventory.json
+++ b/libraries/default/meta_fields/enisa-csirt-inventory.json
@@ -4,7 +4,7 @@
         {
             "field": "ISO 3166-1 Code",
             "type": "text",
-            "regex": "[a-z]{2,3}"
+            "regex": "[A-Za-z]{2,3}"
         },
         {
             "field": "website",
@@ -74,5 +74,5 @@
     "scope": "organisation",
     "source": "enisa.europa.eu/topics/csirts-in-europe/csirt-inventory/certs-by-country-interactive-map",
     "uuid": "089c68c7-d97e-4f21-a798-159cd10f7864",
-    "version": 3
+    "version": 4
 }


### PR DESCRIPTION
The `ISO 3166-1 Code` field rejects the uppercase form that the standard actually specifies.

```json
{ "field": "ISO 3166-1 Code", "type": "text", "regex": "[a-z]{2,3}" }
```

Applied as `/^[a-z]{2,3}$/m`.

| pattern | `IE` | `ie` | `IRL` |
|---|---|---|---|
| `[a-z]{2,3}` | n | y | n |
| `[A-Za-z]{2,3}` | y | y | y |

ISO 3166-1 alpha-2 and alpha-3 codes are defined in uppercase, so the convention most operators type is the one that fails.

## Changes

- widen to `[A-Za-z]{2,3}`
- bump `version` 3 → 4

`[A-Za-z]` rather than `[A-Z]` so that any lowercase values already stored stay valid.