### PR TITLE
Fix/first directory phone regex

### DIFF
--- a/libraries/default/meta_fields/first.json
+++ b/libraries/default/meta_fields/first.json
@@ -2,7 +2,7 @@
     "name": "FIRST Directory",
     "namespace": "first",
     "description": "Template based on the output of the FIRST Directory API",
-    "version": 1,
+    "version": 2,
     "scope": "organisation",
     "uuid": "a89c80d0-7019-422a-b45b-fe59532886c7",
     "source": "FIRST.org API",
@@ -38,7 +38,7 @@
         {
             "field": "website",
             "type": "text",
-            "multiple": 1
+            "multiple": true
         },
         {
             "field": "email",
@@ -47,13 +47,13 @@
         {
             "field": "phone",
             "type": "text",
-            "regex": "/^\\+[0-9\\-]*$/",
-            "multiple": 1
+            "regex": "\\+[0-9\\-]*",
+            "multiple": true
         },
         {
             "field": "phone-emergency",
             "type": "text",
-            "regex": "/^\\+[0-9\\-]*$/"
+            "regex": "\\+[0-9\\-]*"
         },
         {
             "field": "timezone",


### PR DESCRIPTION
The `phone` and `phone-emergency` fields of the FIRST Directory meta-template cannot accept any value, including well-formed phone numbers.

Both regexes are written with PCRE delimiters:

```json
{ "field": "phone", "type": "text", "regex": "/^\\+[0-9\\-]*$/", "multiple": 1 }
```

`MetaFieldsTable::isValidRegex` wraps the stored pattern itself:

```php
$re = $metaTemplateField['regex'];
if (!preg_match("/^$re$/m", $value)) {
```

The effective pattern therefore becomes `/^/^\+[0-9\-]*$/$/m` - the second character closes the delimiter and the remainder is malformed.

Verified:

| pattern | value | result |
|---|---|---|
| `/^\+[0-9\-]*$/` | `+353-1-2345678` | `false` |
| `\+[0-9\-]*` | `+353-1-2345678` | `1` |

## Changes

- strip the delimiters from both fields
- normalise `"multiple": 1` → `true` on the three fields using the integer
  form (unchanged behaviour via truthiness; consistency with the rest of the
  library)
- bump `version` 1 → 2 so existing instances pick the correction up