### PR TITLE
Fix: importer validates meta fields

### DIFF
--- a/src/Command/ImporterCommand.php
+++ b/src/Command/ImporterCommand.php
@@ -45,6 +45,7 @@ class ImporterCommand extends Command
     private $noMetaTemplate = false;
     private $autoYes = false;
     private $updateOnly = false;
+    private $skipValidation = false;
 
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
@@ -80,6 +81,11 @@ class ImporterCommand extends Command
             'default' => false,
             'boolean' => true
         ]);
+        $parser->addOption('skip-validation', [
+            'help' => 'Report meta-field validation failures as warnings and import them anyway, instead of aborting. Values imported this way may not be migratable to a later version of their meta-template.',
+            'default' => false,
+            'boolean' => true
+        ]);
         return $parser;
     }
 
@@ -95,6 +101,7 @@ class ImporterCommand extends Command
         }
         $this->autoYes = $args->getOption('yes');
         $this->updateOnly = $args->getOption('update-only');
+        $this->skipValidation = $args->getOption('skip-validation');
         if ($this->updateOnly && is_null($primary_key)) {
             $io->error('A `primary_key` must be supplied when using `--update-only` mode.');
             die(1);
@@ -161,10 +168,17 @@ class ImporterCommand extends Command
                 ->order(['version' => 'DESC'])
                 ->first();
             if (!is_null($metaTemplate)) {
-                $metaTemplateFieldsMapping = $this->MetaTemplates->MetaTemplateFields->find('list', [
-                    'keyField' => 'field',
-                    'valueField' => 'id'
-                ])->where(['meta_template_id' => $metaTemplate->id])->toArray();
+                $metaTemplateFields = $this->MetaTemplates->MetaTemplateFields->find()
+                    ->where(['meta_template_id' => $metaTemplate->id])
+                    ->all()
+                    ->indexBy('field')
+                    ->toArray();
+                $metaTemplateFieldsMapping = array_map(
+                    function ($metaTemplateField) {
+                        return $metaTemplateField->id;
+                    },
+                    $metaTemplateFields
+                );
             } else {
                 $this->io->error("Unknown template for UUID {$config['metaTemplateUUID']}");
                 die(1);
@@ -204,6 +218,27 @@ class ImporterCommand extends Command
                         }
                         if ($this->canBeOverriden($metaEntity)) {
                             $metaEntity->value = $fieldValue;
+                            if (!is_null($metaEntity->value) && isset($metaTemplateFields[$fieldName])) {
+                                $validationResult = $this->MetaFields->isValidMetaFieldForMetaTemplateField(
+                                    $metaEntity->value,
+                                    $metaTemplateFields[$fieldName]
+                                );
+                                if ($validationResult !== true) {
+                                    $message = is_string($validationResult)
+                                        ? $validationResult
+                                        : __(
+                                            'Metafield value `{0}` for `{1}` is not one of the permitted values.',
+                                            $metaEntity->value,
+                                            $fieldName
+                                        );
+                                    if ($this->skipValidation) {
+                                        $this->io->warning($message);
+                                    } else {
+                                        $hasErrors = true;
+                                        $this->io->error($message);
+                                    }
+                                }
+                            }
                         }
                         $metaFields[] = $metaEntity;
                     }
@@ -215,6 +250,7 @@ class ImporterCommand extends Command
             $this->io->verbose('No validation errors');
         } else {
             $this->io->error('Validation errors, please fix before importing');
+            $this->io->error('Pass --skip-validation to import anyway. Note that values which fail validation cannot be migrated to a later version of their meta-template.');
             die(1);
         }
         return $entities;


### PR DESCRIPTION
Fixes #231 

## What

`cake importer` wrote meta-field values without ever validating them. Regexes,
`values_list` and type handlers were all bypassed, so an import could store
values that the same template rejects through every other route - and that
`migrateMetafieldsToNewestTemplate()` will later refuse to carry to a newer
template version.

## Cause

`marshalData()` builds each meta-field by assigning properties to an empty
entity rather than marshalling input through it:

```php
$metaEntity = $this->MetaFields->newEmptyEntity();
$metaEntity->field = $fieldName;
...
$metaEntity->value = $fieldValue;
```

Direct assignment skips marshalling, and `save()` applies rules, not
validators, so the `validMetaField` rule declared in
`MetaFieldsTable::validationDefault()` never ran at any point.

The intent to validate was already present but could not fire:
`saveMetaFields()` checks `$metaEntity->hasErrors()`, and `hasErrors()` is
populated by marshalling - on an entity that was never marshalled it is always
empty.

## Approach

Each value is validated against its meta-template field as it is assigned, via
`MetaFieldsTable::isValidMetaFieldForMetaTemplateField()`. Failures are
reported the way parent-entity errors already are - every failure listed, then
abort before anything is written.

`patchEntity()` was deliberately not used - `uuid` is required on create but
is only populated by `UUIDBehavior::beforeSave()`, so marshalling at this point
fails on a field the importer is not responsible for supplying. 

`MetaTemplateFields` are now fetched as entities rather than an id list, since
validation needs the `type`, `regex` and `values_list` rather than the primary
key. The existing `$metaTemplateFieldsMapping` is derived from them, so the
surrounding code is unchanged.

## Behaviour change, and workaround

Imports that previously "succeeded" while writing invalid data will now fail.
That is the intent, but it is a behaviour change and existing pipelines may
depend on the current leniency - particularly where an upstream source is
untidier than the template anticipates.

`--skip-validation` downgrades failures to warnings and imports anyway. The
abort message points at it, and both mention that values failing validation
cannot be migrated to a later template version.

## Verifying the behaviour

1. Load a template with a regex-constrained field - `ENISA CSIRT Network` constrains `website` to `https?:\/\/.+`.
2. Map that field to a failing value, e.g. `www.example.org`.
3. `./bin/cake importer <config> <source>` - before this change it reports success and stores the value; after, it reports the failing value and aborts.
4. `--skip-validation` restores the previous behaviour, with warnings.