### PR TITLE
chg: type it_infra_and_services meta_template IP as ipv4

### DIFF
--- a/libraries/default/meta_fields/it_infrastructure_and_services.json
+++ b/libraries/default/meta_fields/it_infrastructure_and_services.json
@@ -2,34 +2,34 @@
     "name": "IT infrastructure and services",
     "namespace": "cerebrate",
     "description": "Offers the possiblity to register the IP of part of the infrastructure or services.",
-    "version": 2,
+    "version": 3,
     "scope": "organisation",
     "uuid": "a7674718-57c8-40e7-969e-d26ca911cb4a",
     "source": "Cerebrate",
     "metaFields": [
         {
             "field": "Microsoft Exchange Server IP",
-            "type": "text",
+            "type": "ipv4",
             "multiple": true
         },
         {
             "field": "Microsfot Office 365 IP",
-            "type": "text",
+            "type": "ipv4",
             "multiple": true
         },
         {
             "field": "Microsoft SharePoint IP",
-            "type": "text",
+            "type": "ipv4",
             "multiple": true
         },
         {
             "field": "Microsoft Active Directory IP",
-            "type": "text",
+            "type": "ipv4",
             "multiple": true
         },
         {
             "field": "Proxy IP",
-            "type": "text",
+            "type": "ipv4",
             "multiple": true
         }
     ]


### PR DESCRIPTION
All five fields in this template were typed `text`, so values matched as
strings. Typed `ipv4`, IPv4Type::setQueryExpression matches by CIDR
containment instead, which is what lets a stored range answer "which
organisation owns this address?".

Given the template exists specifically to "register the IP of part of the
infrastructure or services", string matching forfeits most of its value.

Version bumped 2 -> 3.

This is a tightening change. Instances holding values that are not IPv4 --
hostnames, or IPv6 addresses stored in the absence of a v6 field -- will not
update automatically: getMetaTemplateConflictsForMetaTemplate reports them as
conflicting entities and blocks the automatic path, which is the intended
behaviour for a stricter field. Operators resolve those before updating, and
nothing is silently dropped.

Two related points deliberately left out of this commit: whether matching
ipv6 fields should be added, and the `Microsfot` typo, which cannot be
corrected without discarding stored values because field names are matched
by name on update. 