### PR TITLE
fix(tags): deleting a tag orphans every use/application of it

### DIFF
--- a/config/Migrations/20260809000001_PruneOrphanedTaggings.php
+++ b/config/Migrations/20260809000001_PruneOrphanedTaggings.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+/**
+ * Removes tags_tagged rows whose tag_id no longer resolves to a tags_tags row.
+ *
+ * TagsTable declared no association to Tagged, and tags_tagged.tag_id carries no
+ * foreign key, so every tag deleted before that was corrected left its taggings
+ * behind. The rows are unreachable -- each one names a tag that no longer exists,
+ * and every query that resolves a tagging joins tags_tags, so they are absent
+ * from counts while still occupying the unique index on
+ * (tag_id, fk_id, fk_model).
+ *
+ */
+final class PruneOrphanedTaggings extends AbstractMigration
+{
+    public function up(): void
+    {
+        $orphans = $this->fetchRow(
+            'SELECT COUNT(*) AS c FROM tags_tagged tg
+             WHERE NOT EXISTS (SELECT 1 FROM tags_tags t WHERE t.id = tg.tag_id)'
+        );
+        $count = (int)($orphans['c'] ?? 0);
+
+        if ($count === 0) {
+            return;
+        }
+
+        $this->execute(
+            'DELETE tg FROM tags_tagged tg
+             WHERE NOT EXISTS (SELECT 1 FROM tags_tags t WHERE t.id = tg.tag_id)'
+        );
+
+        // tags_tags.counter is maintained by the CounterCache attached in
+        // TagBehavior::attachCounters(), which a raw DELETE bypasses. Any tag
+        // whose count was inflated by these rows needs correcting -- and the
+        // same drift may predate this migration, so rebuild all of them.
+        $this->execute(
+            'UPDATE tags_tags t
+             SET t.counter = (SELECT COUNT(*) FROM tags_tagged tg WHERE tg.tag_id = t.id)'
+        );
+    }
+
+    /**
+     * Not reversible: the deleted rows referenced tags that no longer exist, so
+     * there is nothing to restore them to.
+     */
+    public function down(): void
+    {
+    }
+}

--- a/plugins/Tags/src/Model/Table/TagsTable.php
+++ b/plugins/Tags/src/Model/Table/TagsTable.php
@@ -16,6 +16,12 @@ class TagsTable extends AppTable
         $this->setTable('tags_tags');
         $this->setDisplayField('name'); // Change to name?
         $this->addBehavior('Timestamp');
+        $this->hasMany('Tagged', [
+            'className' => 'Tags.Tagged',
+            'foreignKey' => 'tag_id',
+            'dependent' => true,
+            'cascadeCallbacks' => true,
+        ]);
     }
 
     public function validationDefault(Validator $validator): Validator


### PR DESCRIPTION
Deleting a tag leaves every `tags_tagged` row that referenced it behind,
pointing at an id that no longer exists.

## Why

`TagsTable::initialize()` declares no association to `Tagged`:

```php
public function initialize(array $config): void
{
    $this->setTable('tags_tags');
    $this->setDisplayField('name');
    $this->addBehavior('Timestamp');
}
```

No `hasMany`, no `dependent => true`, and `tags_tagged.tag_id` carries no
foreign key. `Tags::delete` therefore removes the `tags_tags` row and nothing
touches the taggings.

The orphans are invisible rather than just stale. Every query that resolves a tagging joins `tags_tags`, so the rows disappear from counts while still occupying the unique index on `(tag_id, fk_id, fk_model)`.
`tags_tags.counter`, maintained by the `CounterCache` that `TagBehavior::attachCounters()` attaches, is equally blind to them.

## Changes

- `TagsTable`: add  `hasMany('Tagged', [... 'dependent' => true, 'cascadeCallbacks' => true])`. `cascadeCallbacks` keeps the delete going through the ORM rather than a bulk query.
- New migration pruning rows orphaned before the association existed, and rebuilding `tags_tags.counter` afterwards since a raw `DELETE` bypasses the CounterCache. Any instance that has ever deleted a tag has these.

## Notes

The migration is a no-op where there is nothing to prune, and is not reversible i.e. the rows referenced tags that no longer exist, so there is nothing to restore them to. 

An alternative to the association is a foreign key on `tags_tagged.tag_id` with `ON DELETE CASCADE`. It is cheaper but bypasses the behaviour layer, so I went with the association.

## Verifying

```sql
SELECT COUNT(*) FROM tags_tagged tg
WHERE NOT EXISTS (SELECT 1 FROM tags_tags t WHERE t.id = tg.tag_id);
```

Non-zero before the migration on any instance that has deleted a tag; zero after. Creating a tag, applying it, then deleting it should leave no residue.