### PR TITLE
fix: [meta-fields] add missing boolean and date type handlers

### DIFF
--- a/src/Lib/default/meta_fields_types/BooleanType.php
+++ b/src/Lib/default/meta_fields_types/BooleanType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace MetaFieldsTypes;
+
+use Cake\Database\Expression\QueryExpression;
+use MetaFieldsTypes\TextType;
+
+class BooleanType extends TextType
+{
+    public const OPERATORS = ['=', '!='];
+    public const TYPE = 'boolean';
+
+    /**
+     * Representations accepted as true and as false.
+     *
+     * Deliberately permissive. Meta-field values are strings, `boolean` fields
+     * have never been validated, and shipped templates are populated from
+     * external sources -- ENISA's inventory writes `is-approved`, for instance.
+     * Rejecting anything a reasonable person would call a boolean would strand
+     * existing data: getMetaFieldsConflictsUnderTemplate() re-validates on
+     * migration, so a value that cannot pass here cannot be carried to a newer
+     * version of its template.
+     */
+    public const TRUTHY = ['1', 'true', 'yes', 'on', 'y', 't'];
+    public const FALSEY = ['0', 'false', 'no', 'off', 'n', 'f'];
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Validate the provided value against the expected type
+     *
+     * @param string $value
+     * @return boolean
+     */
+    public function validate(string $value): bool
+    {
+        return !is_null($this->normalise($value));
+    }
+
+    /**
+     * Reduce a stored representation to true, false, or null when unrecognised.
+     *
+     * @param string $value
+     * @return boolean|null
+     */
+    public function normalise(string $value): ?bool
+    {
+        $needle = strtolower(trim($value));
+        if (in_array($needle, self::TRUTHY, true)) {
+            return true;
+        }
+        if (in_array($needle, self::FALSEY, true)) {
+            return false;
+        }
+        return null;
+    }
+
+    /**
+     * Match on meaning rather than on the stored spelling, so a search for `1`
+     * also finds `true` and `yes`.
+     */
+    public function setQueryExpression(QueryExpression $exp, string $searchValue, \App\Model\Entity\MetaTemplateField $metaTemplateField): QueryExpression
+    {
+        $isNegation = substr($searchValue, 0, 1) === '!';
+        if ($isNegation) {
+            $searchValue = substr($searchValue, 1);
+        }
+
+        $wanted = $this->normalise($searchValue);
+        if (is_null($wanted)) {
+            // Not a boolean at all -- fall back to matching the literal string.
+            $textHandler = new TextType();
+            return $textHandler->setQueryExpression($exp, ($isNegation ? '!' : '') . $searchValue, $metaTemplateField);
+        }
+
+        $matching = $wanted ? self::TRUTHY : self::FALSEY;
+        $field = 'MetaFields.value';
+        if ($isNegation) {
+            $exp->notIn($field, $matching);
+        } else {
+            $exp->in($field, $matching);
+        }
+        return $exp;
+    }
+}

--- a/src/Lib/default/meta_fields_types/DateType.php
+++ b/src/Lib/default/meta_fields_types/DateType.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MetaFieldsTypes;
+
+use DateTime;
+use MetaFieldsTypes\TextType;
+
+class DateType extends TextType
+{
+    public const OPERATORS = ['=', '!='];
+    public const TYPE = 'date';
+
+    /**
+     * Formats accepted for a stored date, tried in order.
+     *
+     * Meta-field values are strings and `date` fields have never been
+     * validated, so shipped templates already hold whatever their source
+     * supplied -- `first.json` populates `establishment` and `member-since`
+     * from the FIRST directory. A partial date is meaningful for those: a team
+     * established in 1998 may have no recorded month or day, so `Y` and `Y-m`
+     * are accepted rather than forcing a fabricated precision.
+     *
+     * Day-first and month-first orderings are mutually ambiguous, so only the
+     * unambiguous ISO-style orderings and the day-first European forms are
+     * accepted. `03/04/2026` is read as 3 April.
+     */
+    public const FORMATS = [
+        'Y-m-d',
+        'Y-m-d H:i:s',
+        'Y-m-d\TH:i:sP',
+        'Y-m-d\TH:i:s',
+        'Y/m/d',
+        'd-m-Y',
+        'd/m/Y',
+        'Y-m',
+        'Y',
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Validate the provided value against the expected type
+     *
+     * @param string $value
+     * @return boolean
+     */
+    public function validate(string $value): bool
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return false;
+        }
+        foreach (self::FORMATS as $format) {
+            // The `!` resets unparsed components to the epoch rather than
+            // letting the current date leak into a partial value.
+            $parsed = DateTime::createFromFormat('!' . $format, $value);
+            if ($parsed === false) {
+                continue;
+            }
+            $errors = DateTime::getLastErrors();
+            // PHP < 8.2 returns an array of zero counts; 8.2+ returns false.
+            if (is_array($errors) && (!empty($errors['warning_count']) || !empty($errors['error_count']))) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Model/Table/MetaTemplateFieldsTable.php
+++ b/src/Model/Table/MetaTemplateFieldsTable.php
@@ -9,9 +9,13 @@ use Cake\Validation\Validator;
 use MetaFieldsTypes\TextType;
 use MetaFieldsTypes\IPv4Type;
 use MetaFieldsTypes\IPv6Type;
+use MetaFieldsTypes\BooleanType;
+use MetaFieldsTypes\DateType;
 require_once(APP . 'Lib' . DS . 'default' . DS . 'meta_fields_types' . DS . 'TextType.php');
 require_once(APP . 'Lib' . DS . 'default' . DS . 'meta_fields_types' . DS . 'IPv4Type.php');
 require_once(APP . 'Lib' . DS . 'default' . DS . 'meta_fields_types' . DS . 'IPv6Type.php');
+require_once(APP . 'Lib' . DS . 'default' . DS . 'meta_fields_types' . DS . 'BooleanType.php');
+require_once(APP . 'Lib' . DS . 'default' . DS . 'meta_fields_types' . DS . 'DateType.php');
 
 class MetaTemplateFieldsTable extends AppTable
 {
@@ -76,6 +80,8 @@ class MetaTemplateFieldsTable extends AppTable
                 new TextType(),
                 new IPv4Type(),
                 new IPv6Type(),
+                new BooleanType(),
+                new DateType(),
             ];
             foreach ($typeHandlers as $handler) {
                 $this->typeHandlers[$handler::TYPE] = $handler;


### PR DESCRIPTION

MetaTemplateFieldsTable::loadTypeHandlers() registered only TextType, IPv4Type and IPv6Type, while MetaFieldsTable::isValidType() returns true when no handler is found:
```php
    /*
        We should not end-up in this case. But if someone creates a new type without his handler,
        we consider its type to be a valid text.
    */
    return true;
```
Shipped templates do use both missing types:
 - first.json - `establishment` and `member-since`
 - enisa-csirt-inventory.json - `is-approved` and `cra_designated_csirt`
 - csirt_network_permissions.json - all five `perm_*` fields

csirt_network_permissions is therefore entirely unvalidated -- five permission flags stored as arbitrary text.

The codebase already expects both to exist. MetaTemplateField::_getIndexType() branches on 'boolean' and 'date', and _getFormType() returns a checkbox for 'boolean'. The rendering half was written; the validation half was not.

Both handlers are deliberately permissive. Values are strings, neither type has ever been validated, and the templates using them are populated from external directories, so anything stricter would strand existing data -- getMetaFieldsConflictsUnderTemplate() re-validates on migration, and a value that cannot pass validation cannot be carried to a newer template version.

BooleanType accepts 1/0, true/false, yes/no, on/off and y/n/t/f, case insensitively, and matches on meaning rather than spelling so a search for `1` also finds `true`.

DateType accepts ISO dates and datetimes, ISO 8601 with offset, Y/m/d, the day-first European forms, and the partial forms Y and Y-m -- a team established in 1998 may have no recorded month or day, and forcing a fabricated precision would be worse than accepting the partial value. Calendar validity is enforced, so 2026-02-31 and 2026-13-01 are rejected. Ambiguous month-first orderings are not accepted.